### PR TITLE
Add configure scheduled downtime

### DIFF
--- a/lib/hotdog/application.rb
+++ b/lib/hotdog/application.rb
@@ -43,7 +43,7 @@ module Hotdog
           @options = @options.merge(Hash[loaded.map { |key, value| [Symbol === key ? key : key.to_s.to_sym, value] }])
         end
       end
-      args = @optparse.parse(argv)
+      args = @optparse.order(argv)
 
       unless options[:api_key]
         raise("DATADOG_API_KEY is not set")

--- a/lib/hotdog/commands/down.rb
+++ b/lib/hotdog/commands/down.rb
@@ -6,14 +6,25 @@ module Hotdog
   module Commands
     class Down < BaseCommand
       def run(args=[])
+        if args.index("--start").nil?
+          start = Time.new
+        else
+          start = Time.parse(args[args.index("--start") + 1])
+          args.slice!(args.index("--start"), 2)
+        end
+        if args.index("--downtime").nil?
+          downtime = 86400
+        else
+          downtime = args[args.index("--downtime") + 1].to_i
+          args.slice!(args.index("--downtime"), 2)
+        end
+
         args.each do |arg|
           if arg.index(":").nil?
             scope = "host:#{arg}"
           else
             scope = arg
           end
-          start = Time.new
-          downtime = 86400 # TODO: make configurable
           code, schedule = @dog.schedule_downtime(scope, :start => start.to_i, :end => (start+downtime).to_i)
           logger.debug("dog.schedule_donwtime(%s, :start => %s, :end => %s) #==> [%s, %s]" % [scope.inspect, start.to_i, (start+downtime).to_i, code.inspect, schedule.inspect])
           if code.to_i / 100 != 2


### PR DESCRIPTION
hotdog doesn't allow subcommand option.
This request allows all subcommand options and allow scheduled downtime setting for down command.

```
hotdog down --start 2015-03-20 --downtime 86400 hostname hostname ...
```