### PR TITLE
Add option to show tags which are used in search expressions

### DIFF
--- a/lib/hotdog/application.rb
+++ b/lib/hotdog/application.rb
@@ -29,6 +29,7 @@ module Hotdog
         print0: false,
         print1: true,
         tags: [],
+        display_search_tags: false,
         verbose: false,
       }
       define_options
@@ -106,6 +107,9 @@ module Hotdog
       end
       @optparse.on("-a TAG", "-t TAG", "--tag TAG", "Use specified tag name/value") do |tag|
         options[:tags] += [tag]
+      end
+      @optparse.on("-x", "--display-search-tags", "Show tags used in search expression") do |v|
+        options[:display_search_tags] = v
       end
       @optparse.on("-V", "--[no-]verbose", "Enable verbose mode") do |v|
         options[:verbose] = v

--- a/lib/hotdog/commands.rb
+++ b/lib/hotdog/commands.rb
@@ -56,11 +56,16 @@ module Hotdog
         not host_id.nil?
       end
 
-      def get_hosts(hosts=[])
+      def get_hosts(hosts=[], identifiers=[])
         update_db
-        if 0 < @options[:tags].length
+        if 0 < @options[:tags].length || 0 < identifiers.length
+          tags = if 0 < @options[:tags].length
+                   @options[:tags] + identifiers
+                 else
+                   ["host"] + identifiers
+                 end
           result = hosts.map { |host_id|
-            @options[:tags].map { |tag|
+            tags.map { |tag|
               tag_name, tag_value = tag.split(":", 2)
               case tag_name
               when "host"
@@ -74,7 +79,7 @@ module Hotdog
               end
             }
           }
-          fields = @options[:tags]
+          fields = tags
         else
           if @options[:listing]
             fields = []


### PR DESCRIPTION
This option `-x` and `--display-search-tags` to show tags on search result list automatically.

In many cases, I execute hotdog command like below:
```
$ hotdog search -h tag1:foo and tag2:bar-'*' and tag3:baz -a tag1 -a tag2 -a tag3
tag1 tag2 tag3
---- ---- ----
val1 val2 val3
```
This new option make it very simple:
```
$ hotdog search -x -h tag1:foo and tag2:bar-'*' and tag3:baz
host tag1 tag2 tag3
---- ---- ---- ----
host val1 val2 val3
```

Of course, we can specify additional attributes/tags by using `-a`:
```
$ hotdog search -x -h tag1:foo and tag2:bar-'*' and tag3:baz -a mytag
mytag tag1 tag2 tag3
----- ---- ---- ----
tagT  val1 val2 val3
```
