### PR TITLE
Add 'ssh' subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,12 @@ $ hotdog search availability-zone:us-east-1b and 'name:web-*'
 i-03cb56ed
 ```
 
+Login to the matching host using ssh.
+
+```sh
+$ hotdog ssh availability-zone:us-east-1b and 'name:web-*' -t public_ipv4 -u username
+```
+
 
 ## Expression
 

--- a/lib/hotdog/commands/search.rb
+++ b/lib/hotdog/commands/search.rb
@@ -20,6 +20,18 @@ module Hotdog
           exit(1)
         end
 
+        result = evaluate(node, self).sort
+        if 0 < result.length
+          result, fields = get_hosts_with_search_tags(result, node)
+          STDOUT.print(format(result, fields: fields))
+          logger.info("found %d host(s)." % result.length)
+        else
+          STDERR.puts("no match found: #{args.join(" ")}")
+          exit(1)
+        end
+      end
+
+      def get_hosts_with_search_tags(result, node)
         drilldown = ->(n){
           case
           when n[:left] && n[:right] then drilldown.(n[:left]) + drilldown.(n[:right])
@@ -30,15 +42,7 @@ module Hotdog
         }
         identifiers = drilldown.call(node).map(&:to_s)
 
-        result = evaluate(node, self).sort
-        if 0 < result.length
-          result, fields = get_hosts(result, @options[:display_search_tags] ? identifiers : [])
-          STDOUT.print(format(result, fields: fields))
-          logger.info("found %d host(s)." % result.length)
-        else
-          STDERR.puts("no match found: #{args.join(" ")}")
-          exit(1)
-        end
+        get_hosts(result, @options[:display_search_tags] ? identifiers : [])
       end
 
       def parse(expression)

--- a/lib/hotdog/commands/ssh.rb
+++ b/lib/hotdog/commands/ssh.rb
@@ -59,7 +59,7 @@ module Hotdog
             result = result.each_with_index.map {|host,i| [i] + host }
             fields = ["index"] + fields
 
-            STDOUT.print(format(result, fields: fields))
+            STDERR.print(format(result, fields: fields))
             logger.info("found %d host(s)." % result.length)
             exit(1)
           end

--- a/lib/hotdog/commands/ssh.rb
+++ b/lib/hotdog/commands/ssh.rb
@@ -1,0 +1,90 @@
+#!/usr/bin/env ruby
+
+require "json"
+require "parslet"
+require "hotdog/commands/search"
+require "shellwords"
+
+module Hotdog
+  module Commands
+    class Ssh < Search
+      def run(args=[])
+        ssh_option = {
+          index: nil,
+          options: [],
+          user: nil,
+          identity_file: nil,
+        }
+
+        optparse.on("-n", "--index INDEX", "Use this index of host if multiple servers are found", Integer) do |index|
+          ssh_option[:index] = index
+        end
+        optparse.on("-o SSH_OPTION", "Passes this string to ssh command through shell. This option may be given multiple times") do |option|
+          ssh_option[:options] += [option]
+        end
+        optparse.on("-i SSH_IDENTITY_FILE", "SSH identity file path") do |path|
+          ssh_option[:identity_file] = path
+        end
+        optparse.on("-u SSH_USER", "SSH login user name") do |user|
+          ssh_option[:user] = user
+        end
+
+        args = optparse.parse(args)
+        expression = args.join(" ").strip
+        if expression.empty?
+          exit(1)
+        end
+
+        begin
+          node = parse(expression)
+        rescue Parslet::ParseFailed => error
+          STDERR.puts("syntax error: " + error.cause.ascii_tree)
+          exit(1)
+        end
+
+        result = evaluate(node, self).sort
+
+        if result.length == 1
+          host = result[0]
+        elsif result.empty?
+          STDERR.puts("no match found: #{args.join(" ")}")
+          exit(1)
+        else
+          if ssh_option[:index] && result.length > ssh_option[:index]
+            host = result[ssh_option[:index]]
+          else
+            result, fields = get_hosts_with_search_tags(result, node)
+
+            # add "index" field
+            result = result.each_with_index.map {|host,i| [i] + host }
+            fields = ["index"] + fields
+
+            STDOUT.print(format(result, fields: fields))
+            logger.info("found %d host(s)." % result.length)
+            exit(1)
+          end
+        end
+
+        result, fields = get_hosts([host])
+        address = result.flatten.first
+
+        # build ssh command
+        cmdline = ["ssh"]
+        ssh_option[:options].each do |option|
+          cmdline << "-o" << option
+        end
+        if path = ssh_option[:identity_file]
+          cmdline << "-i" << Shellwords.escape(path)
+        end
+        if user = ssh_option[:user]
+          cmdline << (Shellwords.escape(user) + "@" + address)
+        else
+          cmdline << address
+        end
+
+        exec cmdline.join(" ")
+        exit(127)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This pull-request adds "ssh" subcommand so that we can ssh to a server searched using hotdog's search syntax. For example,

```
$ hotdog ssh -i ~/.ssh/td2.pem -u ubuntu -t public_ipv4 myworker-staging
```

This command searches `myworker-staging` servers, and executes `ssh` command to login there. It uses `public_ipv4` tag as the address of the server.

If it found more than 1 servers, it shows search results with index (0, 1, 2, ...) as following, and exits with status code=1:

```
0 123.157.95.30
1 123.211.51.8
2 123.159.41.13
3 123.205.3.1
4 123.45.251.203
I, [2015-04-02T15:34:39.242518 #36208]  INFO -- : found 5 host(s).
```

Instead of showing above search results, you can use `-n INDEX` option to login to Nth server. In this example, following command logins to "0 123.157.95.30":

```
$ hotdog ssh -i ~/.ssh/td2.pem -u ubuntu -t public_ipv4 myworker-staging -n 0
```

This implementation is simple but this works well at least for my use case.
It would be very nice if I can do following things but it's a different topic:

* instead of starting a shell, execute a command on the remote host and finish
* run multiple ssh commands on all matched remote hosts (like `pssh`)
