### PR TITLE
ssh subcommand accepts command line after '--' that runs on the remote server

### DIFF
--- a/lib/hotdog/commands/ssh.rb
+++ b/lib/hotdog/commands/ssh.rb
@@ -78,13 +78,13 @@ module Hotdog
           cmdline << "-i" << Shellwords.escape(path)
         end
         if user = ssh_option[:user]
-          cmdline << (Shellwords.escape(user) + "@" + address)
+          cmdline << (user + "@" + address)
         else
           cmdline << address
         end
         cmdline.concat(args)
 
-        exec cmdline.join(" ")
+        exec *cmdline
         exit(127)
       end
     end

--- a/lib/hotdog/commands/ssh.rb
+++ b/lib/hotdog/commands/ssh.rb
@@ -29,8 +29,9 @@ module Hotdog
           ssh_option[:user] = user
         end
 
-        args = optparse.parse(args)
-        expression = args.join(" ").strip
+        search_args = []
+        optparse.order!(args) {|search_arg| search_args.push(search_arg) }
+        expression = search_args.join(" ").strip
         if expression.empty?
           exit(1)
         end
@@ -47,7 +48,7 @@ module Hotdog
         if result.length == 1
           host = result[0]
         elsif result.empty?
-          STDERR.puts("no match found: #{args.join(" ")}")
+          STDERR.puts("no match found: #{search_args.join(" ")}")
           exit(1)
         else
           if ssh_option[:index] && result.length > ssh_option[:index]
@@ -81,6 +82,7 @@ module Hotdog
         else
           cmdline << address
         end
+        cmdline.concat(args)
 
         exec cmdline.join(" ")
         exit(127)


### PR DESCRIPTION
This pull-request adds support for remote command execution. Command line is passed after '--' argument. For example,

```
$ hotdog ssh -i ~/.ssh/td2.pem -u ubuntu -t public_ipv4 myworker-staging -- uptime
```
