### PR TITLE
nothing, android, oreo

### DIFF
--- a/lib/hotdog/commands/search.rb
+++ b/lib/hotdog/commands/search.rb
@@ -3,6 +3,19 @@
 require "json"
 require "parslet"
 
+# Monkey patch to prevent `NoMethodError` after some parse error in parselet
+module Parslet
+  class Cause
+    def cause
+      self
+    end
+
+    def backtrace
+      []
+    end
+  end
+end
+
 module Hotdog
   module Commands
     class Search < BaseCommand

--- a/lib/hotdog/commands/search.rb
+++ b/lib/hotdog/commands/search.rb
@@ -127,7 +127,8 @@ module Hotdog
           )
         }
         rule(:expression1) {
-          ( unary_op.as(:unary_op) >> spacing.maybe >> expression.as(:expression) \
+          ( unary_op.as(:unary_op) >> spacing >> expression.as(:expression) \
+          | unary_op.as(:unary_op) >> spacing.maybe >> str('(') >> spacing.maybe >> expression.as(:expression) >> spacing.maybe >> str(')') \
           | expression2 \
           )
         }
@@ -195,10 +196,14 @@ module Hotdog
         }
         rule(:identifier_glob) {
           ( binary_op.absent? >> unary_op.absent? >> identifier.repeat(0) >> (glob >> identifier.maybe).repeat(1) \
+          | binary_op >> identifier.repeat(1) >> (glob >> identifier.maybe).repeat(1) \
+          | unary_op >> identifier.repeat(1) >> (glob >> identifier.maybe).repeat(1) \
           )
         }
         rule(:identifier) {
           ( binary_op.absent? >> unary_op.absent? >> match('[A-Za-z]') >> match('[-./0-9A-Z_a-z]').repeat(0) \
+          | binary_op >> match('[-./0-9A-Z_a-z]').repeat(1) \
+          | unary_op >> match('[-./0-9A-Z_a-z]').repeat(1) \
           )
         }
         rule(:separator) {
@@ -212,10 +217,14 @@ module Hotdog
         }
         rule(:attribute_glob) {
           ( binary_op.absent? >> unary_op.absent? >> attribute.repeat(0) >> (glob >> attribute.maybe).repeat(1) \
+          | binary_op >> attribute.repeat(1) >> (glob >> attribute.maybe).repeat(1) \
+          | unary_op >> attribute.repeat(1) >> (glob >> attribute.maybe).repeat(1) \
           )
         }
         rule(:attribute) {
           ( binary_op.absent? >> unary_op.absent? >> match('[-./0-9:A-Z_a-z]').repeat(1) \
+          | binary_op >> match('[-./0-9:A-Z_a-z]').repeat(1) \
+          | unary_op >> match('[-./0-9:A-Z_a-z]').repeat(1) \
           )
         }
         rule(:glob) {

--- a/spec/parser/parser_spec.rb
+++ b/spec/parser/parser_spec.rb
@@ -94,6 +94,42 @@ describe "parser" do
     expect(cmd.parse("( ( foo ) )")).to eq({identifier: "foo"})
   end
 
+  it "parses 'identifier with prefix and'" do
+    expect(cmd.parse("android")).to eq({identifier: "android"})
+  end
+
+  it "parses 'identifier with infix and'" do
+    expect(cmd.parse("islander")).to eq({identifier: "islander"})
+  end
+
+  it "parses 'identifier with suffix and'" do
+    expect(cmd.parse("mainland")).to eq({identifier: "mainland"})
+  end
+
+  it "parses 'identifier with prefix or'" do
+    expect(cmd.parse("oreo")).to eq({identifier: "oreo"})
+  end
+
+  it "parses 'identifier with infix or'" do
+    expect(cmd.parse("category")).to eq({identifier: "category"})
+  end
+
+  it "parses 'identifier with suffix or'" do
+    expect(cmd.parse("imperator")).to eq({identifier: "imperator"})
+  end
+
+  it "parses 'identifier with prefix not'" do
+    expect(cmd.parse("nothing")).to eq({identifier: "nothing"})
+  end
+
+  it "parses 'identifier with infix not'" do
+    expect(cmd.parse("annotation")).to eq({identifier: "annotation"})
+  end
+
+  it "parses 'identifier with suffix not'" do
+    expect(cmd.parse("forgetmenot")).to eq({identifier: "forgetmenot"})
+  end
+
   it "parses 'foo bar'" do
     expect(cmd.parse("foo bar")).to eq({left: {identifier: "foo"}, binary_op: nil, right: {identifier: "bar"}})
   end


### PR DESCRIPTION
Fixed parse error with leading keyword (e.g. `unary_op`, `binary_op`) in identifiers and attributes.