### PR TITLE
Repeat STDIN to each `ssh` children processes invoked by `pssh`

### DIFF
--- a/lib/hotdog/commands/ssh.rb
+++ b/lib/hotdog/commands/ssh.rb
@@ -158,7 +158,12 @@ module Hotdog
         else
           color = nil
         end
-        IO.popen(cmdline, in: :close, err: [:child, :out]) do |io|
+        if options[:infile]
+          stdin = IO.popen("cat #{Shellwords.shellescape(options[:infile])}")
+        else
+          stdin = :close
+        end
+        IO.popen(cmdline, in: stdin, err: [:child, :out]) do |io|
           io.each_with_index do |s, i|
             if output
               if identifier


### PR DESCRIPTION
This example is dangerous somehow, but is also pretty useful to repeat some contents to remote. Killer feature could be sometime dangerous since it's for killing something 😛 

```sh
% echo echo 'hello, this is $(hostname)' | hotdog pssh environment:development and role:web -- 'eval "$(cat)"'
ip-10-10-151-99.ec2.internal:0:hello, this is ip-10-10-151-99
ip-10-10-155-142.ec2.internal:0:hello, this is ip-10-10-155-142
ip-10-10-157-74.ec2.internal:0:hello, this is ip-10-10-157-74
```