### PR TITLE
Lazy datadog credentials

### DIFF
--- a/lib/hotdog/application.rb
+++ b/lib/hotdog/application.rb
@@ -76,14 +76,6 @@ module Hotdog
           exit(1)
         end
 
-        unless options[:api_key]
-          raise("DATADOG_API_KEY is not set")
-        end
-
-        unless options[:application_key]
-          raise("DATADOG_APPLICATION_KEY is not set")
-        end
-
         if options[:format] == "ltsv"
           options[:headers] = true
         end
@@ -108,6 +100,22 @@ module Hotdog
         else
           exit(1)
         end
+      end
+    end
+
+    def api_key()
+      if @options[:api_key]
+        @options[:api_key]
+      else
+        raise("DATADOG_API_KEY is not set")
+      end
+    end
+
+    def application_key()
+      if options[:application_key]
+        options[:application_key]
+      else
+        raise("DATADOG_APPLICATION_KEY is not set")
       end
     end
 

--- a/lib/hotdog/application.rb
+++ b/lib/hotdog/application.rb
@@ -104,10 +104,15 @@ module Hotdog
     end
 
     def api_key()
-      if @options[:api_key]
-        @options[:api_key]
+      if options[:api_key]
+        options[:api_key]
       else
-        raise("DATADOG_API_KEY is not set")
+        update_api_key!
+        if options[:api_key]
+          options[:api_key]
+        else
+          raise("DATADOG_API_KEY is not set")
+        end
       end
     end
 
@@ -115,7 +120,12 @@ module Hotdog
       if options[:application_key]
         options[:application_key]
       else
-        raise("DATADOG_APPLICATION_KEY is not set")
+        update_application_key!
+        if options[:application_key]
+          options[:application_key]
+        else
+          raise("DATADOG_APPLICATION_KEY is not set")
+        end
       end
     end
 
@@ -237,6 +247,28 @@ module Hotdog
         else
           find_confdir(File.dirname(path))
         end
+      end
+    end
+
+    def update_api_key!()
+      if options[:api_key_command]
+        options[:api_key] = IO.popen(options[:api_key_command]).read.strip
+      else
+        update_keys!
+      end
+    end
+
+    def update_application_key!()
+      if options[:application_key_command]
+        options[:application_key] = IO.popen(options[:application_key_command]).read.strip
+      else
+        update_keys!
+      end
+    end
+
+    def update_keys!()
+      if options[:key_command]
+        options[:api_key], options[:application_key] = IO.popen(options[:key_command]).read.strip.split(":", 2)
       end
     end
   end

--- a/lib/hotdog/commands.rb
+++ b/lib/hotdog/commands.rb
@@ -291,7 +291,7 @@ module Hotdog
       def get_all_tags() #==> Hash<Tag,Array<Host>>
         endpoint = options[:endpoint]
         requests = {all_downtime: "/api/v1/downtime", all_tags: "/api/v1/tags/hosts"}
-        query = URI.encode_www_form(api_key: options[:api_key], application_key: options[:application_key])
+        query = URI.encode_www_form(api_key: application.api_key, application_key: application.application_key)
         begin
           parallelism = Parallel.processor_count
           responses = Hash[Parallel.map(requests, in_threads: parallelism) { |name, request_path|
@@ -323,7 +323,7 @@ module Hotdog
       end
 
       def dog()
-        @dog ||= Dogapi::Client.new(options[:api_key], options[:application_key])
+        @dog ||= Dogapi::Client.new(application.api_key, application.application_key)
       end
 
       def split_tag(tag)


### PR DESCRIPTION
I added new configuration keys of `api_key_command`, `application_key_command` and `key_command`. With this, we can load credentials in lazy fashion from some external command when it actually needed.