### PR TITLE
Add retry for all dogapi calls

### DIFF
--- a/lib/hotdog/commands.rb
+++ b/lib/hotdog/commands.rb
@@ -344,6 +344,18 @@ module Hotdog
         backup.step(-1)
         backup.finish
       end
+
+      def with_retry(options={}, &block)
+        (options[:retry] || 1).times do |i|
+          begin
+            return yield
+          rescue => error
+            logger.warn(error.to_s)
+            sleep(options[:retry_delay] || (1<<i))
+          end
+        end
+        raise("retry count exceeded")
+      end
     end
   end
 end

--- a/lib/hotdog/commands/down.rb
+++ b/lib/hotdog/commands/down.rb
@@ -7,8 +7,8 @@ module Hotdog
     class Down < BaseCommand
       def define_options(optparse, options={})
         default_option(options, :downtime, 86400)
-        default_option(options, :start, Time.new)
         default_option(options, :retry, 5)
+        default_option(options, :start, Time.new)
         optparse.on("--downtime DURATION") do |v|
           options[:downtime] = v.to_i
         end
@@ -30,17 +30,7 @@ module Hotdog
           else
             scope = arg
           end
-          if 0 < options[:retry]
-            options[:retry].times do |i|
-              begin
-                schedule_downtime(scope, options)
-                break
-              rescue => error
-                logger.warn(error.to_s)
-                sleep(options[:retry_delay] || (1<<i))
-              end
-            end
-          else
+          with_retry(options) do
             schedule_downtime(scope, options)
           end
         end

--- a/lib/hotdog/commands/untag.rb
+++ b/lib/hotdog/commands/untag.rb
@@ -6,8 +6,15 @@ module Hotdog
   module Commands
     class Untag < BaseCommand
       def define_options(optparse, options={})
+        default_option(options, :retry, 5)
         default_option(options, :tag_source, "user")
         default_option(options, :tags, [])
+        optparse.on("--retry NUM") do |v|
+          options[:retry] = v.to_i
+        end
+        optparse.on("--retry-delay SECONDS") do |v|
+          options[:retry_delay] = v.to_i
+        end
         optparse.on("--source SOURCE") do |v|
           options[:tag_source] = v
         end
@@ -22,23 +29,18 @@ module Hotdog
 
           if options[:tags].empty?
             # delete all user tags
-            code, detach_tags = dog.detach_tags(host_name, source=options[:tag_source])
-            if code.to_i / 100 != 2
-              raise("dog.detach_tags(#{host_name.inspect}, source=#{options[:tag_source].inspect}) returns [#{code.inspect}, #{detach_tags.inspect}]")
+            with_retry do
+              detach_tags(host_name, source=options[:tag_source])
             end
           else
-            code, host_tags = dog.host_tags(host_name, source=options[:tag_source])
-            if code.to_i / 100 != 2
-              raise("dog.host_tags(#{host_name.inspect}, source=#{options[:tag_source].inspect}) returns [#{code.inspect}, #{host_tags.inspect}]")
-            end
+            host_tags = with_retry { host_tags(host_name, source=options[:tag_source]) }
             old_tags = host_tags["tags"]
             new_tags = old_tags - options[:tags]
             if old_tags == new_tags
               # nop
             else
-              code, update_tags = dog.update_tags(host_name, new_tags, source=options[:tag_source])
-              if code.to_i / 100 != 2
-                raise("dog.update_tags(#{host_name.inspect}, #{new_tags.inspect}, source=#{options[:tag_source].inspect}) returns [#{code.inspect}, #{update_tags.inspect}]")
+              with_retry do
+                update_tags(host_name, new_tags, source=options[:tag_source])
               end
             end
           end
@@ -49,6 +51,31 @@ module Hotdog
           close_db(@db)
         end
         FileUtils.rm_f(File.join(options[:confdir], PERSISTENT_DB))
+      end
+
+      private
+      def detach_tags(host_name, options={})
+        code, detach_tags = dog.detach_tags(host_name, options)
+        if code.to_i / 100 != 2
+          raise("dog.detach_tags(#{host_name.inspect}, #{options.inspect}) returns [#{code.inspect}, #{detach_tags.inspect}]")
+        end
+        detach_tags
+      end
+
+      def host_tags(host_name, options={})
+        code, host_tags = dog.host_tags(host_name, options)
+        if code.to_i / 100 != 2
+          raise("dog.host_tags(#{host_name.inspect}, #{options.inspect}) returns [#{code.inspect}, #{host_tags.inspect}]")
+        end
+        host_tags
+      end
+
+      def update_tags(host_name, tags, options={})
+        code, update_tags = dog.update_tags(host_name, tags, options)
+        if code.to_i / 100 != 2
+          raise("dog.update_tags(#{host_name.inspect}, #{tags.inspect}, #{options.inspect}) returns [#{code.inspect}, #{update_tags.inspect}]")
+        end
+        update_tags
       end
     end
   end

--- a/lib/hotdog/commands/up.rb
+++ b/lib/hotdog/commands/up.rb
@@ -24,17 +24,7 @@ module Hotdog
           end
         }
         all_downtimes = nil
-        if 0 < options[:retry]
-          options[:retry].times do |i|
-            begin
-              all_downtimes = get_all_downtimes(options)
-              break
-            rescue => error
-              logger.warn(error.to_s)
-              sleep(options[:retry_delay] || (1<<i))
-            end
-          end
-        else
+        with_retry(options) do
           all_downtimes = get_all_downtimes(options)
         end
 
@@ -43,17 +33,7 @@ module Hotdog
         }
 
         cancel_downtimes.each do |downtime|
-          if 0 < options[:retry]
-            options[:retry].times do |i|
-              begin
-                cancel_downtime(downtime["id"], options)
-                break
-              rescue => error
-                logger.warn(error.to_s)
-                sleep(options[:retry_delay] || (1<<i))
-              end
-            end
-          else
+          with_retry(options) do
             cancel_downtime(downtime["id"], options)
           end
         end


### PR DESCRIPTION
It's retrying after every error. At least for now duplicated calls must be acceptable.