### PR TITLE
Allow specifying path to SSH configuration as `~/.ssh/config`

### DIFF
--- a/lib/hotdog/commands/scp.rb
+++ b/lib/hotdog/commands/scp.rb
@@ -20,7 +20,7 @@ module Hotdog
           # nop
         end
         if options[:ssh_config]
-          cmdline << "-F" << options[:ssh_config]
+          cmdline << "-F" << File.expand_path(options[:ssh_config])
         end
         if options[:identity_file]
           arguments << "-i" << options[:identity_file]

--- a/lib/hotdog/commands/sftp.rb
+++ b/lib/hotdog/commands/sftp.rb
@@ -22,7 +22,7 @@ module Hotdog
           # nop
         end
         if options[:ssh_config]
-          cmdline << "-F" << options[:ssh_config]
+          cmdline << "-F" << File.expand_path(options[:ssh_config])
         end
         if options[:identity_file]
           arguments << "-i" << options[:identity_file]

--- a/lib/hotdog/commands/ssh.rb
+++ b/lib/hotdog/commands/ssh.rb
@@ -120,7 +120,7 @@ module Hotdog
           cmdline << "-A"
         end
         if options[:ssh_config]
-          cmdline << "-F" << options[:ssh_config]
+          cmdline << "-F" << File.expand_path(options[:ssh_config])
         end
         if options[:identity_file]
           cmdline << "-i" << options[:identity_file]


### PR DESCRIPTION
We need to _resolve_ the path name just before using it because the value may come from `~/.hotdog/config.yml`.