### PR TITLE
Add retry to mutation to SQLite database

### DIFF
--- a/lib/hotdog/commands/down.rb
+++ b/lib/hotdog/commands/down.rb
@@ -41,9 +41,13 @@ module Hotdog
         }
         if 0 < hosts.length
           if open_db
-            hosts.each_slice(SQLITE_LIMIT_COMPOUND_SELECT) do |hosts|
-              execute_db(@db, "DELETE FROM hosts_tags WHERE host_id IN ( SELECT id FROM hosts WHERE name IN (%s) )" % hosts.map { "?" }.join(", "), hosts)
-              execute_db(@db, "DELETE FROM hosts WHERE name IN (%s)" % hosts.map { "?" }.join(", "), hosts)
+            with_retry do
+              @db.transaction do
+                hosts.each_slice(SQLITE_LIMIT_COMPOUND_SELECT) do |hosts|
+                  execute_db(@db, "DELETE FROM hosts_tags WHERE host_id IN ( SELECT id FROM hosts WHERE name IN (%s) )" % hosts.map { "?" }.join(", "), hosts)
+                  execute_db(@db, "DELETE FROM hosts WHERE name IN (%s)" % hosts.map { "?" }.join(", "), hosts)
+                end
+              end
             end
           end
         end

--- a/lib/hotdog/commands/tag.rb
+++ b/lib/hotdog/commands/tag.rb
@@ -38,9 +38,13 @@ module Hotdog
           end
         end
         if open_db
-          create_tags(@db, options[:tags])
-          options[:tags].each do |tag|
-            associae_tag_hosts(@db, tag, hosts)
+          with_retry do
+            @db.transaction do
+              create_tags(@db, options[:tags])
+              options[:tags].each do |tag|
+                associae_tag_hosts(@db, tag, hosts)
+              end
+            end
           end
         end
       end

--- a/lib/hotdog/commands/untag.rb
+++ b/lib/hotdog/commands/untag.rb
@@ -53,8 +53,12 @@ module Hotdog
           remove_db
         else
           if open_db
-            options[:tags].each do |tag|
-              disassociate_tag_hosts(@db, tag, hosts)
+            with_retry do
+              @db.transaction do
+                options[:tags].each do |tag|
+                  disassociate_tag_hosts(@db, tag, hosts)
+                end
+              end
             end
           end
         end


### PR DESCRIPTION
workaround for `SQLite3::BusyException: database is locked`