### PR TITLE
Remove version dependency from gemspec

### DIFF
--- a/hotdog.gemspec
+++ b/hotdog.gemspec
@@ -18,15 +18,15 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.7"
-  spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "rspec", "~> 3.3.0"
-  spec.add_development_dependency "rubocop", "~> 0.35.1"
+  spec.add_development_dependency "bundler"
+  spec.add_development_dependency "rake"
+  spec.add_development_dependency "rspec"
+  spec.add_development_dependency "rubocop"
 
-  spec.add_dependency "dogapi", ">= 1.13.0"
-  spec.add_dependency "multi_json", "~> 1.11.2"
-  spec.add_dependency "oj", "~> 2.12.14"
-  spec.add_dependency "parallel", "~> 1.6.1"
-  spec.add_dependency "parslet", "~> 1.6.2"
-  spec.add_dependency "sqlite3", "~> 1.3.10"
+  spec.add_dependency "dogapi"
+  spec.add_dependency "multi_json"
+  spec.add_dependency "oj"
+  spec.add_dependency "parallel"
+  spec.add_dependency "parslet"
+  spec.add_dependency "sqlite3"
 end


### PR DESCRIPTION
* oj 2.12.14 doesn't work Ruby 2.4 because of Integer Unification
* too strict version specification prevents noticing compatibility issues.
  * hotdog as CLI should use latest libraries to notice breakage faster.
    It should specify versions after it really hit the issue.
  * applications using hotdog should lock versions by Gemfile.lock.