### PR TITLE
make the json output more legible when headers are requested

### DIFF
--- a/lib/hotdog/formatters/json.rb
+++ b/lib/hotdog/formatters/json.rb
@@ -8,9 +8,13 @@ module Hotdog
       def format(result, options={})
         result = prepare(result)
         if options[:headers] and options[:fields]
-          result.unshift(options[:fields])
+          result.map! do |record|
+            Hash[options[:fields].zip(record)]
+          end
+          JSON.pretty_generate(result) + newline
+        else
+          JSON.pretty_generate(result) + newline
         end
-        JSON.pretty_generate(result) + newline
       end
     end
   end

--- a/spec/formatter/json_spec.rb
+++ b/spec/formatter/json_spec.rb
@@ -40,26 +40,21 @@ describe "json" do
     }
     expect(fmt.format([["foo", "aaa", 1], ["bar", "bbb", 2], ["baz", "ccc", 3]], options)).to eq(<<-EOS)
 [
-  [
-    "key1",
-    "key2",
-    "val1"
-  ],
-  [
-    "foo",
-    "aaa",
-    1
-  ],
-  [
-    "bar",
-    "bbb",
-    2
-  ],
-  [
-    "baz",
-    "ccc",
-    3
-  ]
+  {
+    "key1": "foo",
+    "key2": "aaa",
+    "val1": 1
+  },
+  {
+    "key1": "bar",
+    "key2": "bbb",
+    "val1": 2
+  },
+  {
+    "key1": "baz",
+    "key2": "ccc",
+    "val1": 3
+  }
 ]
     EOS
   end


### PR DESCRIPTION
**current**
```json
[
  [
    "ssh_ipv4",
    "role"
  ],
  [
    "172.18.167.158",
    "api3-console"
  ],
  [
    "172.18.135.39",
    "api3-console"
  ]
]
```

**after**
```json
[
  {
    "ssh_ipv4": "172.18.151.74",
    "role": "api3-console"
  },
  {
    "ssh_ipv4": "172.18.167.158",
    "role": "api3-console"
  },
  {
    "ssh_ipv4": "172.18.135.39",
    "role": "api3-console"
  }
]
```

The fact that the output structure looks fairly different with headers and without bothers me a bit, but...

Alternative approaches would be:
* use a different format identifier (e.g. ldjson instead of json) and leave the original json format untouched for backwards compatibility
* force headers on when using json format (`options[:headers]` is assumed 'true')
