### PR TITLE
Fix status handling in ssh

### DIFF
--- a/lib/hotdog/application.rb
+++ b/lib/hotdog/application.rb
@@ -163,6 +163,17 @@ module Hotdog
       options.fetch(:status, STATUS_RUNNING)
     end
 
+    def status_name()
+      {
+        STATUS_PENDING       => "pending",
+        STATUS_RUNNING       => "running",
+        STATUS_SHUTTING_DOWN => "shutting-down",
+        STATUS_TERMINATED    => "terminated",
+        STATUS_STOPPING      => "stopping",
+        STATUS_STOPPED       => "stopped",
+      }.fetch(self.status, "unknown")
+    end
+
     private
     def define_options
       @optparse.on("--endpoint ENDPOINT", "Datadog API endpoint") do |endpoint|


### PR DESCRIPTION
Sometime `hotdog ssh` returns no result since its `index` filtering worked too early. I moved the filtering after the evaluation of the expression.