### PR TITLE
`@source` and `@status`

### DIFF
--- a/lib/hotdog/application.rb
+++ b/lib/hotdog/application.rb
@@ -163,17 +163,6 @@ module Hotdog
       options.fetch(:status, STATUS_RUNNING)
     end
 
-    def status_name()
-      {
-        STATUS_PENDING       => "pending",
-        STATUS_RUNNING       => "running",
-        STATUS_SHUTTING_DOWN => "shutting-down",
-        STATUS_TERMINATED    => "terminated",
-        STATUS_STOPPING      => "stopping",
-        STATUS_STOPPED       => "stopped",
-      }.fetch(self.status, "unknown")
-    end
-
     private
     def define_options
       @optparse.on("--endpoint ENDPOINT", "Datadog API endpoint") do |endpoint|

--- a/lib/hotdog/application.rb
+++ b/lib/hotdog/application.rb
@@ -159,8 +159,29 @@ module Hotdog
       end
     end
 
+    def source()
+      options.fetch(:source, SOURCE_DATADOG)
+    end
+
+    def source_name(source=self.source)
+      {
+        SOURCE_DATADOG => "datadog",
+      }.fetch(source, "unknown")
+    end
+
     def status()
       options.fetch(:status, STATUS_RUNNING)
+    end
+
+    def status_name(status=self.status)
+      {
+        STATUS_PENDING       => "pending",
+        STATUS_RUNNING       => "running",
+        STATUS_SHUTTING_DOWN => "shutting-down",
+        STATUS_TERMINATED    => "terminated",
+        STATUS_STOPPING      => "stopping",
+        STATUS_STOPPED       => "stopped",
+      }.fetch(status, "unknown")
     end
 
     private
@@ -204,22 +225,38 @@ module Hotdog
       @optparse.on("-h", "--[no-]headers", "Display headeres for each columns") do |v|
         options[:headers] = v
       end
+      @optparse.on("--source=SOURCE", "Specify custom host source") do |v|
+        case v
+        when /\A\d\z/i
+          options[:source] = v.to_i
+        when /\A(?:all|any)\z/i
+          options[:source] = nil
+        when /\A(?:datadog)\z/i
+          options[:source] = SOURCE_DATADOG
+        else
+          raise(OptionParser::InvalidArgument.new("unknown source: #{v}"))
+        end
+      end
       @optparse.on("--status=STATUS", "Specify custom host status") do |v|
         case v
-        when /\Apending\z/i
+        when /\A\d\z/i
+          options[:status] = v.to_i
+        when /\A(?:all|any)\z/i
+          options[:status] = nil
+        when /\A(?:pending)\z/i
           options[:status] = STATUS_PENDING
-        when /\Arunning\z/i
+        when /\A(?:running)\z/i
           options[:status] = STATUS_RUNNING
-        when /\Ashutting-down\z/i
+        when /\A(?:shutting-down)\z/i
           options[:status] = STATUS_SHUTTING_DOWN
-        when /\Aterminated\z/i
+        when /\A(?:terminated)\z/i
           options[:status] = STATUS_TERMINATED
-        when /\Astopping\z/i
+        when /\A(?:stopping)\z/i
           options[:status] = STATUS_STOPPING
-        when /\Astopped\z/i
+        when /\A(?:stopped)\z/i
           options[:status] = STATUS_STOPPED
         else
-          options[:status] = v.to_i
+          raise(OptionParser::InvalidArgument.new("unknown status: #{v}"))
         end
       end
       @optparse.on("-l", "--[no-]listing", "Use listing format") do |v|

--- a/lib/hotdog/commands.rb
+++ b/lib/hotdog/commands.rb
@@ -81,15 +81,6 @@ module Hotdog
       end
 
       def get_hosts(host_ids, tags=nil)
-        status = application.status
-        n = Array(host_ids).length
-        host_ids = Array(host_ids).each_slice(SQLITE_LIMIT_COMPOUND_SELECT).flat_map { |host_ids|
-          execute("SELECT id FROM hosts WHERE status = ? AND id IN (%s);" % host_ids.map { "?" }.join(", "), [status] + host_ids).map { |row| row[0] }
-        }
-        m = host_ids.length
-        if n != m
-          logger.warn("filtered out #{n - m} host(s) out of #{n} due to status != #{application.status}.")
-        end
         tags ||= @options[:tags]
         update_db
         if host_ids.empty?
@@ -296,32 +287,21 @@ module Hotdog
           execute_db(db, "CREATE UNIQUE INDEX IF NOT EXISTS hosts_tags_host_id_tag_id ON hosts_tags (host_id, tag_id);")
 
           execute_db(db, "CREATE TABLE IF NOT EXISTS source_names (id INTEGER PRIMARY KEY AUTOINCREMENT, name VARCHAR(200) NOT NULL COLLATE NOCASE);")
-          [
-            SOURCE_DATADOG,
-          ].each do |source_id|
-            source_name = {
-              SOURCE_DATADOG => "datadog",
-            }.fetch(source_id, "unknown")
+          {
+            SOURCE_DATADOG => application.source_name(SOURCE_DATADOG),
+          }.each do |source_id, source_name|
             execute_db(db, "INSERT OR IGNORE INTO source_names (id, name) VALUES (?, ?);", [source_id, source_name])
           end
                      
           execute_db(db, "CREATE TABLE IF NOT EXISTS status_names (id INTEGER PRIMARY KEY AUTOINCREMENT, name VARCHAR(200) NOT NULL COLLATE NOCASE);")
-          [
-            STATUS_PENDING,
-            STATUS_RUNNING,
-            STATUS_SHUTTING_DOWN,
-            STATUS_TERMINATED,
-            STATUS_STOPPING,
-            STATUS_STOPPED,
-          ].each do |status_id|
-            status_name = {
-              STATUS_PENDING       => "pending",
-              STATUS_RUNNING       => "running",
-              STATUS_SHUTTING_DOWN => "shutting-down",
-              STATUS_TERMINATED    => "terminated",
-              STATUS_STOPPING      => "stopping",
-              STATUS_STOPPED       => "stopped",
-            }.fetch(status_id, "unknown")
+          {
+            STATUS_PENDING       => application.status_name(STATUS_PENDING),
+            STATUS_RUNNING       => application.status_name(STATUS_RUNNING),
+            STATUS_SHUTTING_DOWN => application.status_name(STATUS_SHUTTING_DOWN),
+            STATUS_TERMINATED    => application.status_name(STATUS_TERMINATED),
+            STATUS_STOPPING      => application.status_name(STATUS_STOPPING),
+            STATUS_STOPPED       => application.status_name(STATUS_STOPPED),
+          }.each do |status_id, status_name|
             execute_db(db, "INSERT OR IGNORE INTO status_names (id, name) VALUES (?, ?);", [status_id, status_name])
           end
 

--- a/lib/hotdog/commands.rb
+++ b/lib/hotdog/commands.rb
@@ -369,13 +369,25 @@ module Hotdog
             [host, status]
           })
         end
+
         # create virtual `host` tag
         execute_db(db, "INSERT OR IGNORE INTO tags (name, value) SELECT 'host', hosts.name FROM hosts;")
-        q = "INSERT OR REPLACE INTO hosts_tags (host_id, tag_id) " \
+        execute_db(db,
+            "INSERT OR REPLACE INTO hosts_tags (host_id, tag_id) " \
               "SELECT hosts.id, tags.id FROM hosts " \
                 "INNER JOIN ( SELECT * FROM tags WHERE name = 'host' ) AS tags " \
                   "ON hosts.name = tags.value;"
-        execute_db(db, q)
+        )
+
+        # create virtual `@host` tag
+        execute_db(db, "INSERT OR IGNORE INTO tags (name, value) SELECT '@host', hosts.name FROM hosts;")
+        execute_db(db,
+            "INSERT OR REPLACE INTO hosts_tags (host_id, tag_id) " \
+              "SELECT hosts.id, tags.id FROM hosts " \
+                "INNER JOIN ( SELECT * FROM tags WHERE name = '@host' ) AS tags " \
+                  "ON hosts.name = tags.value;"
+        )
+
       end
 
       def create_tags(db, tags)

--- a/lib/hotdog/commands/search.rb
+++ b/lib/hotdog/commands/search.rb
@@ -120,6 +120,14 @@ module Hotdog
           # return everything if given expression is empty
           expression = "*"
         end
+        if options[:source]
+          source_name = application.source_name(options[:source])
+          expression = "@source:#{source_name} AND (#{expression})"
+        end
+        if options[:status]
+          status_name = application.status_name(options[:status])
+          expression = "@status:#{status_name} AND (#{expression})"
+        end
         if options[:limit]
           expression = "LIMIT((#{expression}), #{options[:limit]})"
         end

--- a/lib/hotdog/expression/syntax.rb
+++ b/lib/hotdog/expression/syntax.rb
@@ -106,9 +106,9 @@ module Hotdog
         )
       }
       rule(:tag) {
-        ( regexp.as(:tagname_regexp) >> separator.as(:separator) >> regexp.as(:tagvalue_regexp) \
-        | regexp.as(:tagname_regexp) >> separator.as(:separator) \
-        | regexp.as(:tagname_regexp) \
+        ( tagname_regexp.as(:tagname_regexp) >> separator.as(:separator) >> tagvalue_regexp.as(:tagvalue_regexp) \
+        | tagname_regexp.as(:tagname_regexp) >> separator.as(:separator) \
+        | tagname_regexp.as(:tagname_regexp) \
         | tagname_glob.as(:tagname_glob) >> separator.as(:separator) >> tagvalue_glob.as(:tagvalue_glob) \
         | tagname_glob.as(:tagname_glob) >> separator.as(:separator) >> tagvalue.as(:tagvalue) \
         | tagname_glob.as(:tagname_glob) >> separator.as(:separator) \
@@ -117,6 +117,10 @@ module Hotdog
         | tagname.as(:tagname) >> separator.as(:separator) >> tagvalue.as(:tagvalue) \
         | tagname.as(:tagname) >> separator.as(:separator) \
         | tagname.as(:tagname) \
+        | (str('@') >> tagname).as(:tagname) >> separator.as(:separator) >> tagvalue_glob.as(:tagvalue_glob) \
+        | (str('@') >> tagname).as(:tagname) >> separator.as(:separator) >> tagvalue.as(:tagvalue) \
+        | (str('@') >> tagname).as(:tagname) >> separator.as(:separator) \
+        | (str('@') >> tagname).as(:tagname) \
         | separator.as(:separator) >> regexp.as(:tagvalue_regexp) \
         | separator.as(:separator) >> tagvalue_glob.as(:tagvalue_glob) \
         | separator.as(:separator) >> tagvalue.as(:tagvalue) \


### PR DESCRIPTION
Introduced new internal tags of `@host`, `@source` and `@status`. This allows users to use these internal hosts's attribute as a part of expression.