### PR TITLE
Rewrite the references to `host` by `@host`

### DIFF
--- a/lib/hotdog/expression.rb
+++ b/lib/hotdog/expression.rb
@@ -64,77 +64,77 @@ module Hotdog
         UnaryExpressionNode.new(unary_op, expression)
       }
       rule(tagname_regexp: simple(:tagname_regexp), separator: simple(:separator), tagvalue_regexp: simple(:tagvalue_regexp)) {
-        if "/host/" == tagname_regexp
+        if "/@host/" == tagname_regexp or "/host/" == tagname_regexp
           RegexpHostNode.new(tagvalue_regexp, separator)
         else
           RegexpTagNode.new(tagname_regexp, tagvalue_regexp, separator)
         end
       }
       rule(tagname_regexp: simple(:tagname_regexp), separator: simple(:separator)) {
-        if "/host/" == tagname_regexp
+        if "/@host/" == tagname_regexp or "/host/" == tagname_regexp
           EverythingNode.new()
         else
           RegexpTagnameNode.new(tagname_regexp, separator)
         end
       }
       rule(tagname_regexp: simple(:tagname_regexp)) {
-        if "/host/" == tagname_regexp
+        if "/@host/" == tagname_regexp or "/host/" == tagname_regexp
           EverythingNode.new()
         else
           RegexpHostOrTagNode.new(tagname_regexp)
         end
       }
       rule(tagname_glob: simple(:tagname_glob), separator: simple(:separator), tagvalue_glob: simple(:tagvalue_glob)) {
-        if "host" == tagname_glob
+        if "@host" == tagname_glob or "host" == tagname_glob
           GlobHostNode.new(tagvalue_glob, separator)
         else
           GlobTagNode.new(tagname_glob, tagvalue_glob, separator)
         end
       }
       rule(tagname_glob: simple(:tagname_glob), separator: simple(:separator), tagvalue: simple(:tagvalue)) {
-        if "host" == tagname_glob
+        if "@host" == tagname_glob or "host" == tagname_glob
           GlobHostNode.new(tagvalue, separator)
         else
           GlobTagNode.new(tagname_glob, tagvalue, separator)
         end
       }
       rule(tagname_glob: simple(:tagname_glob), separator: simple(:separator)) {
-        if "host" == tagname_glob
+        if "@host" == tagname_glob or "host" == tagname_glob
           EverythingNode.new()
         else
           GlobTagnameNode.new(tagname_glob, separator)
         end
       }
       rule(tagname_glob: simple(:tagname_glob)) {
-        if "host" == tagname_glob
+        if "@host" == tagname_glob or "host" == tagname_glob
           EverythingNode.new()
         else
           GlobHostOrTagNode.new(tagname_glob)
         end
       }
       rule(tagname: simple(:tagname), separator: simple(:separator), tagvalue_glob: simple(:tagvalue_glob)) {
-        if "host" == tagname
+        if "@host" == tagname or "host" == tagname
           GlobHostNode.new(tagvalue_glob, separator)
         else
           GlobTagNode.new(tagname, tagvalue_glob, separator)
         end
       }
       rule(tagname: simple(:tagname), separator: simple(:separator), tagvalue: simple(:tagvalue)) {
-        if "host" == tagname
+        if "@host" == tagname or "host" == tagname
           StringHostNode.new(tagvalue, separator)
         else
           StringTagNode.new(tagname, tagvalue, separator)
         end
       }
       rule(tagname: simple(:tagname), separator: simple(:separator)) {
-        if "host" == tagname
+        if "@host" == tagname or "host" == tagname
           EverythingNode.new()
         else
           StringTagnameNode.new(tagname, separator)
         end
       }
       rule(tagname: simple(:tagname)) {
-        if "host" == tagname
+        if "@host" == tagname or "host" == tagname
           EverythingNode.new()
         else
           StringHostOrTagNode.new(tagname)

--- a/lib/hotdog/expression/semantics.rb
+++ b/lib/hotdog/expression/semantics.rb
@@ -746,7 +746,7 @@ module Hotdog
 
     class AnyHostNode < TagExpressionNode
       def initialize(separator=nil, options={})
-        super("host", nil, separator, options)
+        super("@host", nil, separator, options)
       end
 
       def condition(options={})
@@ -767,7 +767,7 @@ module Hotdog
 
     class StringHostNode < StringExpressionNode
       def initialize(tagvalue, separator=nil, options={})
-        super("host", tagvalue.to_s, separator, options)
+        super("@host", tagvalue.to_s, separator, options)
       end
 
       def condition(options={})
@@ -918,7 +918,7 @@ module Hotdog
 
     class GlobHostNode < GlobExpressionNode
       def initialize(tagvalue, separator=nil, options={})
-        super("host", tagvalue.to_s, separator, options)
+        super("@host", tagvalue.to_s, separator, options)
       end
 
       def condition(options={})
@@ -1073,7 +1073,7 @@ module Hotdog
         when /\A\/(.*)\/\z/
           tagvalue = $1
         end
-        super("host", tagvalue, separator, options)
+        super("@host", tagvalue, separator, options)
       end
 
       def condition(options={})

--- a/spec/core/commands_spec.rb
+++ b/spec/core/commands_spec.rb
@@ -27,7 +27,7 @@ describe "commands" do
     allow(cmd).to receive(:execute).with("SELECT id FROM hosts WHERE status = ? AND id IN (?, ?, ?);", [Hotdog::STATUS_RUNNING, 1, 2, 3]) {
       [[1], [2], [3]]
     }
-    allow(cmd).to receive(:get_hosts_fields).with([1, 2, 3], ["host"])
+    allow(cmd).to receive(:get_hosts_fields).with([1, 2, 3], ["@host"])
     expect(cmd.__send__(:get_hosts, [1, 2, 3], []))
   end
 
@@ -68,7 +68,7 @@ describe "commands" do
     allow(cmd).to receive(:execute).with(q1.join(" "), [1, 2, 3]) {
       [["foo"], ["bar"], ["baz"]]
     }
-    allow(cmd).to receive(:get_hosts_fields).with([1, 2, 3], ["host", "foo", "bar", "baz"])
+    allow(cmd).to receive(:get_hosts_fields).with([1, 2, 3], ["@host", "foo", "bar", "baz"])
     expect(cmd.__send__(:get_hosts, [1, 2, 3], []))
   end
 
@@ -87,7 +87,7 @@ describe "commands" do
     allow(cmd).to receive(:execute).with(q1.join(" "), [1, 2, 3]) {
       [["foo"], ["bar"], ["baz"]]
     }
-    allow(cmd).to receive(:get_hosts_fields).with([1, 2, 3], ["bar", "host", "foo", "baz"])
+    allow(cmd).to receive(:get_hosts_fields).with([1, 2, 3], ["bar", "@host", "foo", "baz"])
     expect(cmd.__send__(:get_hosts, [1, 2, 3], []))
   end
 
@@ -127,15 +127,15 @@ describe "commands" do
           "WHERE hosts_tags.host_id = ? AND tags.name IN (?, ?, ?)",
             "GROUP BY tags.name;",
     ]
-    allow(cmd).to receive(:execute).with(q1.join(" "), [1, "foo", "bar", "host"]) {
-      [["foo", "foo1"], ["bar", "bar1"], ["host", "host1"]]
+    allow(cmd).to receive(:execute).with(q1.join(" "), [1, "foo", "bar", "@host"]) {
+      [["foo", "foo1"], ["bar", "bar1"], ["@host", "host1"]]
     }
-    allow(cmd).to receive(:execute).with(q1.join(" "), [2, "foo", "bar", "host"]) {
-      [["foo", "foo2"], ["bar", "bar2"], ["host", "host2"]]
+    allow(cmd).to receive(:execute).with(q1.join(" "), [2, "foo", "bar", "@host"]) {
+      [["foo", "foo2"], ["bar", "bar2"], ["@host", "host2"]]
     }
-    allow(cmd).to receive(:execute).with(q1.join(" "), [3, "foo", "bar", "host"]) {
-      [["foo", "foo3"], ["bar", "bar3"], ["host", "host3"]]
+    allow(cmd).to receive(:execute).with(q1.join(" "), [3, "foo", "bar", "@host"]) {
+      [["foo", "foo3"], ["bar", "bar3"], ["@host", "host3"]]
     }
-    expect(cmd.__send__(:get_hosts_fields, [1, 2, 3], ["foo", "bar", "host"])).to eq([[["foo1", "bar1", "host1"], ["foo2", "bar2", "host2"], ["foo3", "bar3", "host3"]], ["foo", "bar", "host"]])
+    expect(cmd.__send__(:get_hosts_fields, [1, 2, 3], ["foo", "bar", "@host"])).to eq([[["foo1", "bar1", "host1"], ["foo2", "bar2", "host2"], ["foo3", "bar3", "host3"]], ["foo", "bar", "@host"]])
   end
 end

--- a/spec/evaluator/glob_expression_spec.rb
+++ b/spec/evaluator/glob_expression_spec.rb
@@ -24,7 +24,7 @@ describe "tag glob expression" do
       [[1], [2], [3]]
     }
     expect(expr.evaluate(cmd)).to eq([1, 2, 3])
-    expect(expr.dump).to eq({tagname_glob: "host", separator: ":", tagvalue_glob: "foo*"})
+    expect(expr.dump).to eq({tagname_glob: "@host", separator: ":", tagvalue_glob: "foo*"})
   end
 
   it "interprets tag glob with tagname and tagvalue" do

--- a/spec/evaluator/regexp_expression_spec.rb
+++ b/spec/evaluator/regexp_expression_spec.rb
@@ -24,7 +24,7 @@ describe "tag regexp expression" do
       [[1], [2], [3]]
     }
     expect(expr.evaluate(cmd)).to eq([1, 2, 3])
-    expect(expr.dump).to eq({tagname_regexp: "host", separator: ":", tagvalue_regexp: "foo"})
+    expect(expr.dump).to eq({tagname_regexp: "@host", separator: ":", tagvalue_regexp: "foo"})
   end
 
   it "interprets tag regexp with tagname and tagvalue" do

--- a/spec/evaluator/string_expression_spec.rb
+++ b/spec/evaluator/string_expression_spec.rb
@@ -24,7 +24,7 @@ describe "tag expression" do
       [[1], [2], [3]]
     }
     expect(expr.evaluate(cmd)).to eq([1, 2, 3])
-    expect(expr.dump).to eq({tagname: "host", separator: ":", tagvalue: "foo"})
+    expect(expr.dump).to eq({tagname: "@host", separator: ":", tagvalue: "foo"})
   end
 
   it "interprets tag with tagname and tagvalue" do

--- a/spec/optimizer/glob_expression_spec.rb
+++ b/spec/optimizer/glob_expression_spec.rb
@@ -9,7 +9,7 @@ describe "tag glob expression" do
     it "interprets tag glob with host (#{o})" do
       expr = Hotdog::Expression::GlobHostNode.new("foo*", ":")
       expect(optimize_n(o+1, expr).dump).to eq({
-        tagname_glob: "host",
+        tagname_glob: "@host",
         separator: ":",
         tagvalue_glob: "foo*",
         fallback: {

--- a/spec/optimizer/regexp_expression_spec.rb
+++ b/spec/optimizer/regexp_expression_spec.rb
@@ -9,7 +9,7 @@ describe "tag regexp expression" do
     it "interprets tag regexp with host (#{o})" do
       expr = Hotdog::Expression::RegexpHostNode.new("foo", ":")
       expect(optimize_n(o+1, expr).dump).to eq({
-        tagname_regexp: "host",
+        tagname_regexp: "@host",
          separator: ":",
          tagvalue_regexp: "foo",
       })

--- a/spec/optimizer/string_expression_spec.rb
+++ b/spec/optimizer/string_expression_spec.rb
@@ -9,7 +9,7 @@ describe "tag expression" do
     it "interprets tag with host (#{o})" do
       expr = Hotdog::Expression::StringHostNode.new("foo", ":")
       expect(optimize_n(o+1, expr).dump).to eq({
-        tagname: "host",
+        tagname: "@host",
         separator: ":",
         tagvalue: "foo",
         fallback: {

--- a/spec/optimizer/unary_expression_spec.rb
+++ b/spec/optimizer/unary_expression_spec.rb
@@ -104,7 +104,7 @@ describe "unary expression" do
         ),
       )
       expect(optimize_n(o+1, expr).dump).to eq({
-        tagname: "host",
+        tagname: "@host",
         separator: ":",
         tagvalue: "foo",
         fallback: {
@@ -140,7 +140,7 @@ describe "unary expression" do
         Hotdog::Expression::StringHostNode.new("foo", ":"),
       )
       expect(optimize_n(o+1, expr).dump).to eq({
-        tagname: "host",
+        tagname: "@host",
         separator: ":",
         tagvalue: "foo",
         fallback: {
@@ -162,7 +162,7 @@ describe "unary expression" do
         ),
       )
       expect(optimize_n(o+1, expr).dump).to eq({
-        tagname: "host",
+        tagname: "@host",
         separator: ":",
         tagvalue: "foo",
         fallback: {
@@ -187,7 +187,7 @@ describe "unary expression" do
         ),
       )
       expect(optimize_n(o+1, expr).dump).to eq({
-        tagname: "host",
+        tagname: "@host",
         separator: ":",
         tagvalue: "foo",
         fallback: {
@@ -263,7 +263,7 @@ describe "unary expression" do
         ),
       )
       expect(optimize_n(o+1, expr).dump).to eq({
-        tagname: "host",
+        tagname: "@host",
         separator: ":",
         tagvalue: "foo",
         fallback: {
@@ -288,7 +288,7 @@ describe "unary expression" do
         ),
       )
       expect(optimize_n(o+1, expr).dump).to eq({
-        tagname: "host",
+        tagname: "@host",
         separator: ":",
         tagvalue: "foo",
         fallback: {
@@ -313,7 +313,7 @@ describe "unary expression" do
         ),
       )
       expect(optimize_n(o+1, expr).dump).to eq({
-        tagname: "host",
+        tagname: "@host",
         separator: ":",
         tagvalue: "foo",
         fallback: {


### PR DESCRIPTION
Starting from v0.31.0, hotdog started using _internal_ tags with leading `@` in name. This workaround is to keep legacy `host` tag for backward compatibility by rewriting it as the reference to the internal tag of `@host` without any user action.

With 1000+ hosts, it reduced the result SQLite database size in few hundreds KBs.