### PR TITLE
support custom data source

### DIFF
--- a/lib/hotdog/commands.rb
+++ b/lib/hotdog/commands.rb
@@ -1,22 +1,16 @@
 #!/usr/bin/env ruby
 
 require "fileutils"
-require "dogapi"
-require "multi_json"
-require "oj"
-require "open-uri"
-require "parallel"
 require "sqlite3"
-require "uri"
 
 module Hotdog
   module Commands
     class BaseCommand
       def initialize(application)
         @application = application
+        @source_provider = application.source_provider
         @logger = application.logger
         @options = application.options
-        @dog = nil # lazy initialization
         @prepared_statements = {}
         @persistent_db_path = File.join(@options.fetch(:confdir, "."), "hotdog.sqlite3")
       end
@@ -262,25 +256,20 @@ module Hotdog
 
       def create_db(db, options={})
         options = @options.merge(options)
+        
         requests = {all_downtimes: "/api/v1/downtime", all_tags: "/api/v1/tags/hosts"}
         begin
-          parallelism = Parallel.processor_count
-          # generate payload before forking threads to avoid fetching keys multiple times
-          query = URI.encode_www_form(api_key: application.api_key, application_key: application.application_key)
-          responses = Hash[Parallel.map(requests, in_threads: parallelism) { |name, request_path|
-            [name, datadog_get(request_path, query)]
-          }]
+          all_tags = @source_provider.get_all_tags()
+          all_downtimes = @source_provider.get_all_downtimes()
         rescue => error
           STDERR.puts(error.message)
           exit(1)
         end
-        all_tags = prepare_tags(responses.fetch(:all_tags, {}))
-        all_downtimes = prepare_downtimes(responses.fetch(:all_downtimes, {}))
         if not all_downtimes.empty?
           logger.info("ignore host(s) with scheduled downtimes: #{all_downtimes.inspect}")
         end
         db.transaction do
-          execute_db(db, "CREATE TABLE IF NOT EXISTS hosts (id INTEGER PRIMARY KEY AUTOINCREMENT, name VARCHAR(255) NOT NULL COLLATE NOCASE, source INTEGER NOT NULL DEFAULT #{SOURCE_DATADOG}, status INTEGER NOT NULL DEFAULT #{STATUS_PENDING});")
+          execute_db(db, "CREATE TABLE IF NOT EXISTS hosts (id INTEGER PRIMARY KEY AUTOINCREMENT, name VARCHAR(255) NOT NULL COLLATE NOCASE, source INTEGER NOT NULL DEFAULT #{@source_provider.id}, status INTEGER NOT NULL DEFAULT #{STATUS_PENDING});")
           execute_db(db, "CREATE UNIQUE INDEX IF NOT EXISTS hosts_name ON hosts (name);")
           execute_db(db, "CREATE TABLE IF NOT EXISTS tags (id INTEGER PRIMARY KEY AUTOINCREMENT, name VARCHAR(200) NOT NULL COLLATE NOCASE, value VARCHAR(200) NOT NULL COLLATE NOCASE);")
           execute_db(db, "CREATE UNIQUE INDEX IF NOT EXISTS tags_name_value ON tags (name, value);")
@@ -288,11 +277,7 @@ module Hotdog
           execute_db(db, "CREATE UNIQUE INDEX IF NOT EXISTS hosts_tags_host_id_tag_id ON hosts_tags (host_id, tag_id);")
 
           execute_db(db, "CREATE TABLE IF NOT EXISTS source_names (id INTEGER PRIMARY KEY AUTOINCREMENT, name VARCHAR(200) NOT NULL COLLATE NOCASE);")
-          {
-            SOURCE_DATADOG => application.source_name(SOURCE_DATADOG),
-          }.each do |source_id, source_name|
-            execute_db(db, "INSERT OR IGNORE INTO source_names (id, name) VALUES (?, ?);", [source_id, source_name])
-          end
+          execute_db(db, "INSERT OR IGNORE INTO source_names (id, name) VALUES (?, ?);", [@source_provider.id, @source_provider.name])
                      
           execute_db(db, "CREATE TABLE IF NOT EXISTS status_names (id INTEGER PRIMARY KEY AUTOINCREMENT, name VARCHAR(200) NOT NULL COLLATE NOCASE);")
           {
@@ -343,42 +328,12 @@ module Hotdog
         end
       end
 
-      def datadog_get(request_path, query=nil)
-        # TODO: make this pluggable
-        endpoint = options[:endpoint]
-        query ||= URI.encode_www_form(api_key: application.api_key, application_key: application.application_key)
-        uri = URI.join(endpoint, "#{request_path}?#{query}")
-        begin
-          response = uri.open("User-Agent" => "hotdog/#{Hotdog::VERSION}") { |fp| fp.read }
-          MultiJson.load(response)
-        rescue OpenURI::HTTPError => error
-          code, _body = error.io.status
-          raise(RuntimeError.new("datadog: GET #{request_path} returns [#{code.inspect}, ...]"))
-        end
-      end
-
-      def prepare_tags(tags)
-        Hash(tags).fetch("tags", {})
-      end
-
-      def prepare_downtimes(downtimes)
-        now = Time.new.to_i
-        Array(downtimes).select { |downtime|
-          # active downtimes
-          downtime["active"] and ( downtime["start"].nil? or downtime["start"] < now ) and ( downtime["end"].nil? or now <= downtime["end"] ) and downtime["monitor_id"].nil?
-        }.flat_map { |downtime|
-          # find host scopes
-          downtime["scope"].select { |scope| scope.start_with?("host:") }.map { |scope| scope.sub(/\Ahost:/, "") }
-        }
-      end
-
       def create_hosts(db, hosts, downtimes)
         hosts.each_slice(SQLITE_LIMIT_COMPOUND_SELECT / 3) do |hosts|
           q = "INSERT OR IGNORE INTO hosts (name, source, status) VALUES %s;" % hosts.map { "(?, ?, ?)" }.join(", ")
           execute_db(db, q, hosts.map { |host|
-            source = SOURCE_DATADOG
             status = downtimes.include?(host) ? STATUS_STOPPED : STATUS_RUNNING
-            [host, source, status]
+            [host, @source_provider.id, status]
           })
         end
 
@@ -445,10 +400,6 @@ module Hotdog
                 "WHERE tag_id IN ( SELECT id FROM tags WHERE name = ? AND value = ? LIMIT 1 ) AND host_id IN ( SELECT id FROM hosts WHERE name IN (%s) );" % hosts.map { "?" }.join(", ")
           execute_db(db, q, split_tag(tag) + hosts)
         end
-      end
-
-      def dog()
-        @dog ||= Dogapi::Client.new(application.api_key, application.application_key)
       end
 
       def split_tag(tag)

--- a/lib/hotdog/commands.rb
+++ b/lib/hotdog/commands.rb
@@ -258,7 +258,10 @@ module Hotdog
         options = @options.merge(options)
         begin
           all_tags = @source_provider.get_all_tags()
-          all_downtimes = @source_provider.get_all_downtimes()
+          all_downtimes = @source_provider.get_all_downtimes().flat_map { |downtime|
+            # find host scopes
+            Array(downtime["scope"]).select { |scope| scope.start_with?("host:") }.map { |scope| scope.sub(/\Ahost:/, "") }
+          }
         rescue => error
           STDERR.puts(error.message)
           exit(1)

--- a/lib/hotdog/commands.rb
+++ b/lib/hotdog/commands.rb
@@ -256,8 +256,6 @@ module Hotdog
 
       def create_db(db, options={})
         options = @options.merge(options)
-        
-        requests = {all_downtimes: "/api/v1/downtime", all_tags: "/api/v1/tags/hosts"}
         begin
           all_tags = @source_provider.get_all_tags()
           all_downtimes = @source_provider.get_all_downtimes()

--- a/lib/hotdog/commands/down.rb
+++ b/lib/hotdog/commands/down.rb
@@ -1,7 +1,5 @@
 #!/usr/bin/env ruby
 
-require "fileutils"
-
 module Hotdog
   module Commands
     class Down < BaseCommand
@@ -70,19 +68,9 @@ module Hotdog
         end
         scopes.each do |scope|
           with_retry(options) do
-            schedule_downtime(scope, options)
+            @source_provider.schedule_downtime(scope, options)
           end
         end
-      end
-
-      private
-      def schedule_downtime(scope, options={})
-        code, schedule = dog.schedule_downtime(scope, :start => options[:start].to_i, :end => (options[:start]+options[:downtime]).to_i)
-        logger.debug("dog.schedule_donwtime(%s, :start => %s, :end => %s) #==> [%s, %s]" % [scope.inspect, options[:start].to_i, (options[:start]+options[:downtime]).to_i, code.inspect, schedule.inspect])
-        if code.to_i / 100 != 2
-          raise("dog.schedule_downtime(%s, ...) returns [%s, %s]" % [scope.inspect, code.inspect, schedule.inspect])
-        end
-        schedule
       end
     end
   end

--- a/lib/hotdog/commands/search.rb
+++ b/lib/hotdog/commands/search.rb
@@ -120,10 +120,6 @@ module Hotdog
           # return everything if given expression is empty
           expression = "*"
         end
-        if options[:source]
-          source_name = application.source_name(options[:source])
-          expression = "@source:#{source_name} AND (#{expression})"
-        end
         if options[:status]
           status_name = application.status_name(options[:status])
           expression = "@status:#{status_name} AND (#{expression})"

--- a/lib/hotdog/commands/tag.rb
+++ b/lib/hotdog/commands/tag.rb
@@ -1,7 +1,5 @@
 #!/usr/bin/env ruby
 
-require "fileutils"
-
 module Hotdog
   module Commands
     class Tag < BaseCommand
@@ -41,32 +39,15 @@ module Hotdog
         hosts.each do |host|
           if options[:tags].empty?
             # nop; just show current tags
-            host_tags = with_retry { host_tags(host, source=options[:tag_source]) }
+            host_tags = with_retry { @source_provider.host_tags(host, source=options[:tag_source]) }
             STDOUT.puts host_tags['tags'].inspect
           else
             # add all as user tags
             with_retry(options) do
-              add_tags(host, options[:tags], source=options[:tag_source])
+              @source_provider.add_tags(host, options[:tags], source=options[:tag_source])
             end
           end
         end
-      end
-
-      private
-      def add_tags(host_name, tags, options={})
-        code, resp = dog.add_tags(host_name, tags, options)
-        if code.to_i / 100 != 2
-          raise("dog.add_tags(#{host_name.inspect}, #{tags.inspect}, #{options.inspect}) returns [#{code.inspect}, #{resp.inspect}]")
-        end
-        resp
-      end
-
-      def host_tags(host_name, options={})
-        code, host_tags = dog.host_tags(host_name, options)
-        if code.to_i / 100 != 2
-          raise("dog.host_tags(#{host_name.inspect}, #{options.inspect}) returns [#{code.inspect}, #{host_tags.inspect}]")
-        end
-        host_tags
       end
     end
   end

--- a/lib/hotdog/commands/tag.rb
+++ b/lib/hotdog/commands/tag.rb
@@ -15,7 +15,7 @@ module Hotdog
         optparse.on("--retry-delay SECONDS") do |v|
           options[:retry_delay] = v.to_i
         end
-        optparse.on("--source SOURCE") do |v|
+        optparse.on("--tag-source SOURCE") do |v|
           options[:tag_source] = v
         end
         optparse.on("-a TAG", "-t TAG", "--tag TAG", "Use specified tag name/value") do |v|

--- a/lib/hotdog/commands/untag.rb
+++ b/lib/hotdog/commands/untag.rb
@@ -1,7 +1,5 @@
 #!/usr/bin/env ruby
 
-require "fileutils"
-
 module Hotdog
   module Commands
     class Untag < BaseCommand
@@ -48,46 +46,21 @@ module Hotdog
           if options[:tags].empty?
             # delete all user tags
             with_retry do
-              detach_tags(host, source=options[:tag_source])
+              @source_provider.detach_tags(host, source=options[:tag_source])
             end
           else
-            host_tags = with_retry { host_tags(host, source=options[:tag_source]) }
+            host_tags = with_retry { @source_provider.host_tags(host, source=options[:tag_source]) }
             old_tags = host_tags["tags"]
             new_tags = old_tags - options[:tags]
             if old_tags == new_tags
               # nop
             else
               with_retry do
-                update_tags(host, new_tags, source=options[:tag_source])
+                @source_provider.update_tags(host, new_tags, source=options[:tag_source])
               end
             end
           end
         end
-      end
-
-      private
-      def detach_tags(host_name, options={})
-        code, detach_tags = dog.detach_tags(host_name, options)
-        if code.to_i / 100 != 2
-          raise("dog.detach_tags(#{host_name.inspect}, #{options.inspect}) returns [#{code.inspect}, #{detach_tags.inspect}]")
-        end
-        detach_tags
-      end
-
-      def host_tags(host_name, options={})
-        code, host_tags = dog.host_tags(host_name, options)
-        if code.to_i / 100 != 2
-          raise("dog.host_tags(#{host_name.inspect}, #{options.inspect}) returns [#{code.inspect}, #{host_tags.inspect}]")
-        end
-        host_tags
-      end
-
-      def update_tags(host_name, tags, options={})
-        code, update_tags = dog.update_tags(host_name, tags, options)
-        if code.to_i / 100 != 2
-          raise("dog.update_tags(#{host_name.inspect}, #{tags.inspect}, #{options.inspect}) returns [#{code.inspect}, #{update_tags.inspect}]")
-        end
-        update_tags
       end
     end
   end

--- a/lib/hotdog/commands/untag.rb
+++ b/lib/hotdog/commands/untag.rb
@@ -15,7 +15,7 @@ module Hotdog
         optparse.on("--retry-delay SECONDS") do |v|
           options[:retry_delay] = v.to_i
         end
-        optparse.on("--source SOURCE") do |v|
+        optparse.on("--tag-source SOURCE") do |v|
           options[:tag_source] = v
         end
         optparse.on("-a TAG", "-t TAG", "--tag TAG", "Use specified tag name/value") do |v|

--- a/lib/hotdog/commands/up.rb
+++ b/lib/hotdog/commands/up.rb
@@ -1,7 +1,5 @@
 #!/usr/bin/env ruby
 
-require "fileutils"
-
 module Hotdog
   module Commands
     class Up < BaseCommand
@@ -25,7 +23,7 @@ module Hotdog
         }
         all_downtimes = nil
         with_retry(options) do
-          all_downtimes = get_all_downtimes(options)
+          all_downtimes = @source_provider.get_all_downtimes(options)
         end
 
         cancel_downtimes = all_downtimes.select { |downtime|
@@ -34,7 +32,7 @@ module Hotdog
 
         cancel_downtimes.each do |downtime|
           with_retry(options) do
-            cancel_downtime(downtime["id"], options)
+            @source_provider.cancel_downtime(downtime["id"], options)
           end
         end
 
@@ -56,23 +54,6 @@ module Hotdog
             end
           end
         end
-      end
-
-      private
-      def get_all_downtimes(options={})
-        code, all_downtimes = dog.get_all_downtimes()
-        if code.to_i / 100 != 2
-          raise("dog.get_all_downtimes() returns [%s, %s]" % [code.inspect, all_downtimes.inspect])
-        end
-        all_downtimes
-      end
-
-      def cancel_downtime(id, options={})
-        code, cancel = dog.cancel_downtime(id)
-        if code.to_i / 100 != 2
-          raise("dog.cancel_downtime(%s) returns [%s, %s]" % [id.inspect, code.inspect, cancel.inspect])
-        end
-        cancel
       end
     end
   end

--- a/lib/hotdog/sources.rb
+++ b/lib/hotdog/sources.rb
@@ -59,6 +59,9 @@ module Hotdog
       def detach_tags(*args)
         raise(NotImplementedError)
       end
+
+      def update_tags(*args)
+      end
     end
   end
 end

--- a/lib/hotdog/sources.rb
+++ b/lib/hotdog/sources.rb
@@ -1,0 +1,64 @@
+#!/usr/bin/env ruby
+
+module Hotdog
+  module Sources
+    class BaseSource
+      def initialize(application)
+        @application = application
+        @logger = application.logger
+        @options = application.options
+      end
+      attr_reader :application
+      attr_reader :logger
+      attr_reader :options
+
+      def id()
+        raise(NotImplementedError)
+      end
+
+      def name()
+        raise(NotImplementedError)
+      end
+
+      def endpoint()
+        options[:endpoint]
+      end
+
+      def api_key()
+        options[:api_key]
+      end
+
+      def application_key()
+        options[:application_key]
+      end
+
+      def schedule_downtime(*args)
+        raise(NotImplementedError)
+      end
+
+      def cancel_downtime(*args)
+        raise(NotImplementedError)
+      end
+
+      def get_all_downtimes()
+        raise(NotImplementedError)
+      end
+
+      def get_all_tags()
+        raise(NotImplementedError)
+      end
+
+      def get_host_tags()
+        raise(NotImplementedError)
+      end
+
+      def add_tags(*args)
+        raise(NotImplementedError)
+      end
+
+      def detach_tags(*args)
+        raise(NotImplementedError)
+      end
+    end
+  end
+end

--- a/lib/hotdog/sources.rb
+++ b/lib/hotdog/sources.rb
@@ -61,6 +61,7 @@ module Hotdog
       end
 
       def update_tags(*args)
+        raise(NotImplementedError)
       end
     end
   end

--- a/lib/hotdog/sources/datadog.rb
+++ b/lib/hotdog/sources/datadog.rb
@@ -55,14 +55,21 @@ module Hotdog
         end
       end
 
-      def schedule_downtime(*args)
-        # TODO
-        super
+      def schedule_downtime(scope, options={})
+        code, schedule = dog.schedule_downtime(scope, :start => options[:start].to_i, :end => (options[:start]+options[:downtime]).to_i)
+        logger.debug("dog.schedule_donwtime(%s, :start => %s, :end => %s) #==> [%s, %s]" % [scope.inspect, options[:start].to_i, (options[:start]+options[:downtime]).to_i, code.inspect, schedule.inspect])
+        if code.to_i / 100 != 2
+          raise("dog.schedule_downtime(%s, ...) returns [%s, %s]" % [scope.inspect, code.inspect, schedule.inspect])
+        end
+        schedule
       end
 
-      def cancel_downtime(*args)
-        # TODO
-        super
+      def cancel_downtime(id, options={})
+        code, cancel = dog.cancel_downtime(id)
+        if code.to_i / 100 != 2
+          raise("dog.cancel_downtime(%s) returns [%s, %s]" % [id.inspect, code.inspect, cancel.inspect])
+        end
+        cancel
       end
 
       def get_all_downtimes()
@@ -73,14 +80,36 @@ module Hotdog
         prepare_tags(datadog_get("/api/v1/tags/hosts"))
       end
 
-      def add_tags(*args)
-        # TODO
-        super
+      def get_host_tags(host_name, options={})
+        code, host_tags = dog.host_tags(host_name, options)
+        if code.to_i / 100 != 2
+          raise("dog.host_tags(#{host_name.inspect}, #{options.inspect}) returns [#{code.inspect}, #{host_tags.inspect}]")
+        end
+        host_tags
       end
 
-      def detach_tags(*args)
-        # TODO
-        super
+      def add_tags(*args)
+        code, resp = dog.add_tags(host_name, tags, options)
+        if code.to_i / 100 != 2
+          raise("dog.add_tags(#{host_name.inspect}, #{tags.inspect}, #{options.inspect}) returns [#{code.inspect}, #{resp.inspect}]")
+        end
+        resp
+      end
+
+      def detach_tags(host_name, options={})
+        code, detach_tags = dog.detach_tags(host_name, options)
+        if code.to_i / 100 != 2
+          raise("dog.detach_tags(#{host_name.inspect}, #{options.inspect}) returns [#{code.inspect}, #{detach_tags.inspect}]")
+        end
+        detach_tags
+      end
+
+      def update_tags(host_name, tags, options={})
+        code, update_tags = dog.update_tags(host_name, tags, options)
+        if code.to_i / 100 != 2
+          raise("dog.update_tags(#{host_name.inspect}, #{tags.inspect}, #{options.inspect}) returns [#{code.inspect}, #{update_tags.inspect}]")
+        end
+        update_tags
       end
 
       private

--- a/lib/hotdog/sources/datadog.rb
+++ b/lib/hotdog/sources/datadog.rb
@@ -1,0 +1,161 @@
+#!/usr/bin/env ruby
+
+require "dogapi"
+require "multi_json"
+require "oj"
+require "open-uri"
+require "uri"
+
+module Hotdog
+  module Sources
+    class Datadog < BaseSource
+      def initialize(application)
+        super(application)
+        options[:endpoint] = ENV.fetch("DATADOG_HOST", "https://app.datadoghq.com")
+        options[:api_key] = ENV["DATADOG_API_KEY"]
+        options[:application_key] = ENV["DATADOG_APPLICATION_KEY"]
+        @dog = nil # lazy initialization
+      end
+
+      def id()
+        Hotdog::SOURCE_DATADOG
+      end
+
+      def name()
+        "datadog"
+      end
+
+      def endpoint()
+        options[:endpoint]
+      end
+
+      def api_key()
+        if options[:api_key]
+          options[:api_key]
+        else
+          update_api_key!
+          if options[:api_key]
+            options[:api_key]
+          else
+            raise("DATADOG_API_KEY is not set")
+          end
+        end
+      end
+
+      def application_key()
+        if options[:application_key]
+          options[:application_key]
+        else
+          update_application_key!
+          if options[:application_key]
+            options[:application_key]
+          else
+            raise("DATADOG_APPLICATION_KEY is not set")
+          end
+        end
+      end
+
+      def schedule_downtime(*args)
+        # TODO
+        super
+      end
+
+      def cancel_downtime(*args)
+        # TODO
+        super
+      end
+
+      def get_all_downtimes()
+        prepare_downtimes(datadog_get("/api/v1/downtime"))
+      end
+
+      def get_all_tags()
+        prepare_tags(datadog_get("/api/v1/tags/hosts"))
+      end
+
+      def add_tags(*args)
+        # TODO
+        super
+      end
+
+      def detach_tags(*args)
+        # TODO
+        super
+      end
+
+      private
+      def dog()
+        @dog ||= Dogapi::Client.new(self.api_key, self.application_key)
+      end
+
+      def datadog_get(request_path, query=nil)
+        query ||= URI.encode_www_form(api_key: self.api_key, application_key: self.application_key)
+        uri = URI.join(self.endpoint, "#{request_path}?#{query}")
+        begin
+          response = uri.open("User-Agent" => "hotdog/#{Hotdog::VERSION}") { |fp| fp.read }
+          MultiJson.load(response)
+        rescue OpenURI::HTTPError => error
+          code, _body = error.io.status
+          raise(RuntimeError.new("datadog: GET #{request_path} returns [#{code.inspect}, ...]"))
+        end
+      end
+
+      def prepare_tags(tags)
+        Hash(tags).fetch("tags", {})
+      end
+
+      def prepare_downtimes(downtimes)
+        now = Time.new.to_i
+        Array(downtimes).select { |downtime|
+          # active downtimes
+          downtime["active"] and ( downtime["start"].nil? or downtime["start"] < now ) and ( downtime["end"].nil? or now <= downtime["end"] ) and downtime["monitor_id"].nil?
+        }.flat_map { |downtime|
+          # find host scopes
+          downtime["scope"].select { |scope| scope.start_with?("host:") }.map { |scope| scope.sub(/\Ahost:/, "") }
+        }
+      end
+
+      def update_api_key!()
+        if options[:api_key_command]
+          logger.info("api_key_command> #{options[:api_key_command]}")
+          options[:api_key] = IO.popen(options[:api_key_command]) do |io|
+            io.read.strip
+          end
+          unless $?.success?
+            raise("failed: #{options[:api_key_command]}")
+          end
+        else
+          update_keys!
+        end
+      end
+
+      def update_application_key!()
+        if options[:application_key_command]
+          logger.info("application_key_command> #{options[:application_key_command]}")
+          options[:application_key] = IO.popen(options[:application_key_command]) do |io|
+            io.read.strip
+          end
+          unless $?.success?
+            raise("failed: #{options[:application_key_command]}")
+          end
+        else
+          update_keys!
+        end
+      end
+
+      def update_keys!()
+        if options[:key_command]
+          logger.info("key_command> #{options[:key_command]}")
+          options[:api_key], options[:application_key] = IO.popen(options[:key_command]) do |io|
+            io.read.strip.split(":", 2)
+          end
+          unless $?.success?
+            raise("failed: #{options[:key_command]}")
+          end
+        end
+      end
+    end
+  end
+end
+
+# vim:set ft=ruby :


### PR DESCRIPTION
Currently the impl is too tightly coupled with DataDog. This PR is to decouple and make DataDog as the default source inventory for future possibility to adopt other sources.