### PR TITLE
Show some human readable error message after config load error

### DIFF
--- a/lib/hotdog/application.rb
+++ b/lib/hotdog/application.rb
@@ -81,7 +81,12 @@ module Hotdog
     def main(argv=[])
       config = File.join(options[:confdir], "config.yml")
       if File.file?(config)
-        loaded = YAML.load(ERB.new(File.read(config)).result)
+        begin
+          loaded = YAML.load(ERB.new(File.read(config)).result)
+        rescue => error
+          STDERR.puts("hotdog: failed to load configuration file at #{config.inspect}: #{error}")
+          exit(1)
+        end
         if Hash === loaded
           @options = @options.merge(Hash[loaded.map { |key, value| [Symbol === key ? key : key.to_s.to_sym, value] }])
         end


### PR DESCRIPTION
YAML loader may raise some exception like follows. Need some appropriate error handling to show some human readable message after such failures.

```rb
irb(main):002:0> YAML.load("---\nfoo: | bar\n")
Psych::SyntaxError: (<unknown>): did not find expected comment or line break while scanning a block scalar at line 2 column 6
        from /home/yyuu/.rbenv/versions/2.4.1/lib/ruby/2.4.0/psych.rb:377:in `parse'
        from /home/yyuu/.rbenv/versions/2.4.1/lib/ruby/2.4.0/psych.rb:377:in `parse_stream'
        from /home/yyuu/.rbenv/versions/2.4.1/lib/ruby/2.4.0/psych.rb:325:in `parse'
        from /home/yyuu/.rbenv/versions/2.4.1/lib/ruby/2.4.0/psych.rb:252:in `load'
        from (irb):2
        from /home/yyuu/.rbenv/versions/2.4.1/bin/irb:11:in `<main>'
```
