### PR TITLE
ssh and pssh prefer primary_tag as hostname

### DIFF
--- a/lib/hotdog/commands/ssh.rb
+++ b/lib/hotdog/commands/ssh.rb
@@ -71,8 +71,16 @@ module Hotdog
         tuples, fields = get_hosts_with_search_tags(result0, node)
         tuples = filter_hosts(tuples)
         validate_hosts!(tuples, fields)
-        logger.info("target host(s): #{tuples.map {|tuple| tuple.first }.inspect}")
-        run_main(tuples.map {|tuple| tuple.first }, options)
+
+        # prefer to use primary_tag as ssh hostname with default to first
+        if primary_tag = options[:primary_tag]
+          host_field_index = fields.find_index(primary_tag)
+        end
+        host_field_index ||= 0
+        hosts = tuples.map {|tuple| tuple[host_field_index] }
+
+        logger.info("target host(s): #{hosts.inspect}")
+        run_main(hosts, options)
       end
 
       private


### PR DESCRIPTION
ssh and pssh commands were using the first element of search results but
it doesn't work well when `tags` option is set at ~/.hotdog/config.yml
and the first element is not a hostname.

This change prefers to use primary_key instead of the first element if
primary_key is set and primary_key is included in the tags option.

If tags option is not set or display_search_tags option is set, behavior
doesn't change because primary_key exists as the first element.