### PR TITLE
Disable fallback behavior by default

### DIFF
--- a/lib/hotdog/application.rb
+++ b/lib/hotdog/application.rb
@@ -49,7 +49,7 @@ module Hotdog
         confdir: find_confdir(File.expand_path(".")),
         debug: false,
         expiry: 3600,
-        fixed_string: false,
+        use_fallback: true,
         force: false,
         format: "text",
         headers: false,
@@ -222,8 +222,11 @@ module Hotdog
       @optparse.on("-d", "--[no-]debug", "Enable debug mode") do |v|
         options[:debug] = v
       end
-      @optparse.on("--fixed-string", "Interpret pattern as fixed string") do |v|
-        options[:fixed_string] = v
+      @optparse.on("--[no-]fixed-string", "Never fallback to alternative expression in case of result is empty. Inversed meaning as '--use-fallback'") do |v|
+        options[:use_fallback] = !v
+      end
+      @optparse.on("--[no-]use-fallback", "Fallback to alternative expressions in case of result is empty. Inversed meaning as '--fixed-string'") do |v|
+        options[:use_fallback] = v
       end
       @optparse.on("-f", "--[no-]force", "Enable force mode") do |v|
         options[:force] = v

--- a/lib/hotdog/application.rb
+++ b/lib/hotdog/application.rb
@@ -49,7 +49,7 @@ module Hotdog
         confdir: find_confdir(File.expand_path(".")),
         debug: false,
         expiry: 3600,
-        use_fallback: true,
+        use_fallback: false,
         force: false,
         format: "text",
         headers: false,

--- a/lib/hotdog/commands.rb
+++ b/lib/hotdog/commands.rb
@@ -28,8 +28,13 @@ module Hotdog
         execute_db(@db, q, args)
       end
 
+      def fallback?()
+        @options[:use_fallback]
+      end
+
       def fixed_string?()
-        @options[:fixed_string]
+        # deprecated - superseded by `fallback?`
+        not @options[:use_fallback]
       end
 
       def reload(options={})

--- a/lib/hotdog/expression/semantics.rb
+++ b/lib/hotdog/expression/semantics.rb
@@ -694,7 +694,7 @@ module Hotdog
             if options[:did_fallback]
               []
             else
-              if not environment.fixed_string? and @options[:fallback]
+              if environment.use_fallback? and @options[:fallback]
                 # avoid optimizing @options[:fallback] to prevent infinite recursion
                 @options[:fallback].evaluate(environment, options.merge(did_fallback: true))
               else


### PR DESCRIPTION
So far the tool is implemented to fallback to alternative expression (typically it's implemented to use some glob'ing for loose matching) in case the given expression didn't match any from inventory. This change is to disable the behavior by default, unless the caller of the command specify either `--use-fallback`.